### PR TITLE
fixes #27: clearing node type access

### DIFF
--- a/content_access.module
+++ b/content_access.module
@@ -653,7 +653,7 @@ function content_access_optimize_grants(&$grants, $node) {
  */
 function content_access_node_type_delete($info) {
   $config = config('content_access.settings');
-  $config->delete('content_access_' . $info->type);
+  $config->clear('content_access_' . $info->type);
   $config->save();
 }
 


### PR DESCRIPTION
Calling the wrong function, delete instead of clear